### PR TITLE
Hide specific ceremonies

### DIFF
--- a/web/src/context/StateContext.tsx
+++ b/web/src/context/StateContext.tsx
@@ -123,7 +123,8 @@ export const useInitialStateContext = () => {
 
       // 2. Post-process data.
       const ceremonies: CeremonyDocumentReferenceAndData[] = docs.map((document: DocumentData) => { return { uid: document.id, data: document.data() } })
-      const projects: Project[] = ceremonies.map((ceremony: CeremonyDocumentReferenceAndData) => { return { ceremony: ceremony } })
+      const ceremoniesVisibleInWeb = ceremonies.filter((ceremony) => ceremony.data.hideInWeb !== true)
+      const projects: Project[] = ceremoniesVisibleInWeb.map((ceremony: CeremonyDocumentReferenceAndData) => { return { ceremony: ceremony } })
 
       const queue: WaitingQueue[] = []
       for (const project of projects) {
@@ -134,7 +135,7 @@ export const useInitialStateContext = () => {
       }
 
       setWaitingQueue(queue)
-      // 3. Store data.      
+      // 3. Store data.
       setProjects(projects)
       setLoading(false)
     }
@@ -142,14 +143,14 @@ export const useInitialStateContext = () => {
     setRunTutorial(true)
 
     fetchData()
-   
+
   },[])
 
   return { waitingQueue, projects, setProjects, circuit, setCircuit, search, setSearch, loading, setLoading, runTutorial, setRunTutorial };
 };
 
 export const StateProvider: React.FC<StateProviderProps> = ({ children }) => {
- 
+
   const [user, setUser] = useState<string | undefined>(
     localStorage.getItem("username") || undefined
   );

--- a/web/src/helpers/interfaces.ts
+++ b/web/src/helpers/interfaces.ts
@@ -171,6 +171,7 @@ export interface CeremonyDocument {
   type: CeremonyType
   coordinatorId: string
   lastUpdated: number
+  hideInWeb?: boolean
 }
 
 /**
@@ -494,9 +495,9 @@ export interface ZkeyDownloadLink {
  * @property {number} waitingQueue - the number of participants in the waiting queue.
  */
 export interface WaitingQueue {
-  ceremonyName: string 
-  circuitName: string 
-  waitingQueue: number 
+  ceremonyName: string
+  circuitName: string
+  waitingQueue: number
 }
 
 /**
@@ -513,7 +514,7 @@ export interface Project {
   circuits?: CircuitDocumentReferenceAndData[] | null
   participants?: ParticipantDocumentReferenceAndData[] | null
   contributions?: ContributionDocumentReferenceAndData[] | null
-  coordinatorId?: string 
+  coordinatorId?: string
 }
 
 export interface State {
@@ -578,6 +579,6 @@ export type StateProviderProps = {
  * @property {string} hash - the hash of the beacon.
  */
 export interface FinalBeacon {
-  beacon: string 
+  beacon: string
   beaconHash: string
 }


### PR DESCRIPTION
# DefinitelySetup Pull Request Template
## Hide specific ceremonies

In case we want to run a ceremony and not publicly advertise it in the ceremony.pse.dev site we can add a new attribute called `hideInWeb` with a boolean value. By default this attribute does not exist so if the value is not set, the ceremony will appear in the website
