### PR TITLE
feat: sort project cards in LandingPage

### DIFF
--- a/web/src/pages/LandingPage/HeroComponent.tsx
+++ b/web/src/pages/LandingPage/HeroComponent.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
   Box,
   Text,
@@ -23,6 +24,17 @@ export function HeroComponent({ projects, waitingQueue }: HeroComponentProps) {
       } `
     })    
   }
+
+  const SortedProjectCards = useMemo(
+    () =>
+      projects
+        .sort((a, b) => b.ceremony.data.endDate - a.ceremony.data.endDate)
+        .map((project) => (
+          <ProjectCard key={project.ceremony.uid} project={project} />
+        )),
+    [projects]
+  )
+
  
   return (
     <>
@@ -53,9 +65,7 @@ export function HeroComponent({ projects, waitingQueue }: HeroComponentProps) {
           <Box width="100%" px={8} py={0}>
             {projects.length > 0 ? (
               <SimpleGrid columns={[1, null, 1]} spacing={0}>
-                {projects.map((project, index) => (
-                  <ProjectCard key={index} project={project} />
-                ))}
+                {SortedProjectCards}
               </SimpleGrid>
             ) : (
               <Text>No ceremonies live yet!</Text>


### PR DESCRIPTION
Closes [#267](https://github.com/privacy-scaling-explorations/p0tion/issues/267) (p0tion repo issue)

### Test plan
I don't have the necessary environment secret/credentials to fetch the real projects data while developing locally, so I manually overrode the projects data e.g by adding [here](https://github.com/privacy-scaling-explorations/DefinitelySetup/blob/8605425a0faf98da7ffe513beacb6794e8324436/web/src/pages/LandingPage/HeroComponent.tsx#L26):
```ts
projects = [
    {
      ceremony: {
        uid: "i3kFOOUi8L42ooRWQh8N",
        // @ts-ignore
        data: {
          title: "example",
          prefix: "example",
          description: "Should be first",
          startDate: new Date("2023-07-01").getTime(),
          endDate: new Date("2025-07-31").getTime(),
          penalty: 3600,
          coordinatorId: "uKm6XEjOKoeZUKAf2goY4vamgHE4",
          lastUpdated: Date.now()
        }
      }
    },
    {
      ceremony: {
        uid: "i3kFOOUi8L42ooRWQh8N",
        // @ts-ignore
        data: {
          title: "example",
          prefix: "example",
          description: "Should be last",
          startDate: new Date("2023-07-01").getTime(),
          endDate: new Date("2023-07-31").getTime(),
          penalty: 3600,
          coordinatorId: "uKm6XEjOKoeZUKAf2goY4vamgHE4",
          lastUpdated: Date.now()
        }
      }
    }
  ]
```

Expected outcome: ceremony with description "should be first" should be displayed on top of the other
![image](https://github.com/privacy-scaling-explorations/DefinitelySetup/assets/38692952/20e308fa-2439-4417-979d-9dfe8c488841)

