### PR TITLE
configuration for EmailApprover V1 ceremony

### DIFF
--- a/ceremonies/email-approver-v1-ceremony/p0tionConfig.json
+++ b/ceremonies/email-approver-v1-ceremony/p0tionConfig.json
@@ -1,0 +1,33 @@
+{
+    "title": "Email Approver V1 Setup Ceremony",
+    "description": "This is a trusted setup ceremony for the Email Approver V1 circuit",
+    "startDate": "2024-06-18T00:00:00",
+    "endDate": "2024-07-18T00:00:00",
+    "timeoutMechanismType": "FIXED",
+    "penalty": 3,
+    "circuits": [
+      {
+          "description": "Email Approver V1 Circuit",
+          "compiler": {
+            "version": "2.1.6",
+            "commitHash": "57b18f68794189753964bfb6e18e64385fed9c2c"
+          },
+          "template": {
+            "source": "https://github.com/SoulWallet/email-approver/blob/main/packages/circuits/EmailApprover.circom",
+            "commitHash": "30ca27e58dcc261aa3aafad2603124157783b640",
+            "paramsConfiguration": []
+          },
+          "verification": {
+            "cfOrVm": "CF"
+          },
+          "artifacts": {
+            "r1csStoragePath": "https://email-approver-v1-definitely-setup.s3.us-west-2.amazonaws.com/EmailApprover.r1cs",
+            "wasmStoragePath": "https://email-approver-v1-definitely-setup.s3.us-west-2.amazonaws.com/EmailApprover.wasm"
+          },
+          "name": "EmailApprover",
+          "fixedTimeWindow": 3,
+          "sequencePosition": 1
+      }
+    ]
+  }
+  


### PR DESCRIPTION
# DefinitelySetup Pull Request Template
## Email Approver V1 Setup Ceremony

This is a trusted setup ceremony for the Email Approver V1 circuit

## Description

EmailApprover is based on [zkemail](https://github.com/zkemail/zk-email-verify) and is currently used to set email guardians for users.

## Uploads

 - [x] R1CS file
 - [x] wasm file
 - [x] Ceremony config file

## Additional Notes

Closes #122 

Confirmation
 - [x] I have read and understood the DefinitelySetup guidelines and requirements.
 - [x] I confirm that all uploaded files are correctly configured and adhere to the guidelines.
