### PR TITLE
feat(web): include compiler version and commit hash in circuit repo link

### DIFF
--- a/web/src/pages/ProjectPage.tsx
+++ b/web/src/pages/ProjectPage.tsx
@@ -83,6 +83,7 @@ const ProjectPage: React.FC = () => {
   const circuitsClean =
     validatedProjectData.circuits?.map((circuit) => ({
       template: circuit.data.template,
+      compiler: circuit.data.compiler,
       name: circuit.data.name,
       description: circuit.data.description,
       constraints: circuit.data.metadata?.constraints,
@@ -495,9 +496,15 @@ const ProjectPage: React.FC = () => {
                               <Stat>
                                 <StatLabel fontSize={12}>Template Link</StatLabel>
                                 <StatNumber fontSize={16}>
-                                  <a href={circuit.template.source} target="_blank">
+                                  <a href={`${circuit.template.source}/tree/${circuit.template.commitHash}`} target="_blank">
                                   {truncateString(circuit.template.source, 16)}
                                   </a>
+                                </StatNumber>
+                              </Stat>
+                              <Stat>
+                                <StatLabel fontSize={12}>Compiler Version</StatLabel>
+                                <StatNumber fontSize={16}>
+                                  {circuit.compiler.version}
                                 </StatNumber>
                               </Stat>
                             </SimpleGrid>


### PR DESCRIPTION
In order to more easily recreate the circuit verifier Solidity contracts, this PR adds the commit hash to the repository link and includes the Circom version on the About tab of the project page.

Previously, I was putting a [breakpoint on this line](https://github.com/privacy-scaling-explorations/DefinitelySetup/blob/main/web/src/context/ProjectPageContext.tsx#L71) and dumping the `circuitsDocs` object to the console to get to these values.

There's still the SnarkJS version as a variable but that's only accessible by looking at the `package.json` file in the repository so at least having the link open to the specific commit makes it easier to find.