### PR TITLE
chore(web): split project page tabs into individual components

### DIFF
--- a/web/src/components/Avatars.tsx
+++ b/web/src/components/Avatars.tsx
@@ -1,15 +1,13 @@
 import React from "react"
 import { Avatar, Box } from "@chakra-ui/react"
 
-interface ScrollingAvatarsProps {
-    images?: string[]
-  }
-  
+import { useProjectPageContext } from "../context/ProjectPageContext";
+
 /**
  * Display the participants Avatars in a scrolling list
- * @param {ScrollingAvatarsProps} - the images to show
  */
-const ScrollingAvatars: React.FC<ScrollingAvatarsProps> = ({ images }) => {
+const ScrollingAvatars: React.FC = () => {
+    const {avatars} = useProjectPageContext();
     return (
       <Box
         maxW={"container.md"}
@@ -20,7 +18,7 @@ const ScrollingAvatars: React.FC<ScrollingAvatarsProps> = ({ images }) => {
         px={2}
         borderColor="gray.200"
       >
-        {images && images.length > 0 && images.map((image: string, index: any) => (
+        {avatars && avatars.length > 0 && avatars.map((image: string, index: any) => (
           <Avatar
             key={index}
             src={image}

--- a/web/src/components/CircuitAbout.tsx
+++ b/web/src/components/CircuitAbout.tsx
@@ -1,0 +1,62 @@
+import {
+  Box,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Heading,
+  Flex,
+  SimpleGrid,
+} from "@chakra-ui/react";
+
+import {
+  truncateString,
+  parseRepoRoot
+} from "../helpers/utils";
+
+export const CircuitAbout: React.FC = ({ circuit }) => {
+  return (
+    <Box borderWidth={1} borderRadius="lg" p={4}>
+      <Heading fontSize={16} size="md" mb={2}>
+        {circuit.name} - {circuit.description}
+      </Heading>
+      <SimpleGrid columns={[2, 2]} spacing={4}>
+        <Flex justify="space-between" align="center">
+          <Stat>
+            <StatLabel fontSize={12}>Parameters</StatLabel>
+            <StatNumber fontSize={16}>
+              {
+                circuit.template.paramsConfiguration && circuit.template.paramsConfiguration.length > 0 ?
+                circuit.template.paramsConfiguration.join(" ") :
+                circuit.template.paramConfiguration && circuit.template.paramConfiguration.length > 0 ?
+                circuit.template.paramConfiguration.join(" ") :
+                "No parameters"
+              }
+            </StatNumber>
+          </Stat>
+        </Flex>
+        <Stat>
+          <StatLabel fontSize={12}>Commit Hash</StatLabel>
+          <StatNumber fontSize={16}>
+            <a href={`${parseRepoRoot(circuit.template.source)}/tree/${circuit.template.commitHash}`} target="_blank">
+              {truncateString(circuit.template.commitHash, 6)}
+            </a>
+          </StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel fontSize={12}>Template Link</StatLabel>
+          <StatNumber fontSize={16}>
+            <a href={circuit.template.source} target="_blank">
+            {truncateString(circuit.template.source, 16)}
+            </a>
+          </StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel fontSize={12}>Compiler Version</StatLabel>
+          <StatNumber fontSize={16}>
+            {circuit.compiler.version}
+          </StatNumber>
+        </Stat>
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/web/src/components/CircuitStats.tsx
+++ b/web/src/components/CircuitStats.tsx
@@ -1,0 +1,74 @@
+import {
+  Box,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Tag,
+  Heading,
+  Flex,
+  Icon,
+  SimpleGrid,
+} from "@chakra-ui/react";
+import { FiTarget, FiZap, FiEye, FiUser, FiMapPin, FiWifi } from "react-icons/fi";
+
+export const CircuitStats: React.FC = ({ circuit }) => {
+  return (
+    <Box borderWidth={1} borderRadius="lg" p={4}>
+      <Heading fontSize={16} size="md" mb={2}>
+        {circuit.name} - {circuit.description}
+      </Heading>
+      <Flex wrap="wrap" mb={4}>
+        <Tag fontSize={10} size="sm" colorScheme="purple" mr={2} mb={2}>
+          <Icon as={FiTarget} mr={1} />
+          Constraints: {circuit.constraints}
+        </Tag>
+        <Tag fontSize={10} size="sm" colorScheme="cyan" mr={2} mb={2}>
+          <Icon as={FiZap} mr={1} />
+          Pot: {circuit.pot}
+        </Tag>
+        <Tag fontSize={10} size="sm" colorScheme="yellow" mr={2} mb={2}>
+          <Icon as={FiEye} mr={1} />
+          Private Inputs: {circuit.privateInputs}
+        </Tag>
+        <Tag fontSize={10} size="sm" colorScheme="pink" mr={2} mb={2}>
+          <Icon as={FiUser} mr={1} />
+          Public Inputs: {circuit.publicInputs}
+        </Tag>
+        <Tag fontSize={10} size="sm" colorScheme="blue" mr={2} mb={2}>
+          <Icon as={FiMapPin} mr={1} />
+          Curve: {circuit.curve}
+        </Tag>
+        <Tag fontSize={10} size="sm" colorScheme="teal" mr={2} mb={2}>
+          <Icon as={FiWifi} mr={1} />
+          Wires: {circuit.wires}
+        </Tag>
+      </Flex>
+      <SimpleGrid columns={[2, 2]} spacing={6}>
+        <Flex justify="space-between" align="center">
+          <Stat>
+            <StatLabel fontSize={12}>Completed Contributions</StatLabel>
+            <StatNumber fontSize={16}>
+              {circuit.completedContributions}
+            </StatNumber>
+          </Stat>
+        </Flex>
+        <Stat>
+          <StatLabel fontSize={12}>Memory Requirement</StatLabel>
+          <StatNumber fontSize={16}>
+            {circuit.memoryRequirement} mb
+          </StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel fontSize={12}>Avg Contribution Time</StatLabel>
+          <StatNumber fontSize={16}>
+            {circuit.avgTimingContribution}s
+          </StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel fontSize={12}>Max Contribution Time</StatLabel>
+          <StatNumber fontSize={16}>{circuit.maxTiming}s</StatNumber>
+        </Stat>
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/web/src/components/ProjectTabAbout.tsx
+++ b/web/src/components/ProjectTabAbout.tsx
@@ -1,0 +1,40 @@
+import {
+  Box,
+  VStack,
+  SimpleGrid,
+  TabPanel,
+} from "@chakra-ui/react";
+
+import { useProjectPageContext } from "../context/ProjectPageContext";
+import { CircuitAbout } from "../components/CircuitAbout";
+
+export const ProjectTabAbout: React.FC = () => {
+  const { circuitsClean } = useProjectPageContext();
+  return (
+    <TabPanel>
+      <VStack
+        alignSelf={"stretch"}
+        alignItems={"center"}
+        justifyContent={"center"}
+        spacing={8}
+        py={0}
+      >
+        <Box alignItems="center" alignSelf={"stretch"} w="full">
+          <SimpleGrid
+            alignSelf={"stretch"}
+            maxW={["392px", "390px", "100%"]}
+            columns={1}
+            spacing={6}
+          >
+            {circuitsClean.map((circuit, index) => (
+              <CircuitAbout
+                key={index}
+                {...{circuit}}
+              />
+            ))}
+          </SimpleGrid>
+        </Box>
+      </VStack>
+    </TabPanel>
+  );
+}

--- a/web/src/components/ProjectTabContributions.tsx
+++ b/web/src/components/ProjectTabContributions.tsx
@@ -1,0 +1,68 @@
+import {
+  Box,
+  HStack,
+  TabPanel,
+  Tag,
+  Heading,
+  Spacer,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tooltip,
+  Tr,
+  Skeleton,
+  Stack,
+} from "@chakra-ui/react";
+
+import { useProjectPageContext } from "../context/ProjectPageContext";
+
+export const ProjectTabContributions: React.FC = () => {
+  const { contributionsClean } = useProjectPageContext();
+  return (
+    <TabPanel alignSelf={"stretch"}>
+      <HStack justifyContent={"space-between"} alignSelf={"stretch"}>
+        <Heading fontSize="18" mb={6} fontWeight={"bold"} letterSpacing={"3%"}>
+          Contributions
+        </Heading>
+        <Spacer />
+      </HStack>
+      <Box overflowX="auto">
+        {!contributionsClean ? (
+          <Stack>
+            <Skeleton height="20px" />
+            <Skeleton height="20px" />
+            <Skeleton height="20px" />
+          </Stack>
+        ) : (
+          <Table fontSize={12} variant="simple">
+            <Thead>
+              <Tr>
+                <Th>Doc</Th>
+                <Th>Contribution Date</Th>
+                <Th>Hashes</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {contributionsClean.map((contribution, index) => (
+                <Tr key={index}>
+                  <Td>{contribution.doc}</Td>
+                  <Td>{contribution.lastUpdated}</Td>
+                  <Td>
+                    <Tooltip
+                      label={contribution.lastZkeyBlake2bHash}
+                      aria-label="Last Zkey Hash"
+                    >
+                      <Tag fontSize={12}>{contribution.lastZkeyBlake2bHash}</Tag>
+                    </Tooltip>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        )}
+      </Box>
+    </TabPanel>
+  );
+}

--- a/web/src/components/ProjectTabStats.tsx
+++ b/web/src/components/ProjectTabStats.tsx
@@ -1,0 +1,32 @@
+import {
+  Box,
+  SimpleGrid,
+  TabPanel,
+} from "@chakra-ui/react";
+
+import { useProjectPageContext } from "../context/ProjectPageContext";
+
+import { CircuitStats } from "../components/CircuitStats";
+
+export const ProjectTabStats: React.FC = () => {
+  const { circuitsClean } = useProjectPageContext();
+  return (
+    <TabPanel>
+      <Box alignItems="center" alignSelf={"stretch"} w="full">
+        <SimpleGrid
+          alignSelf={"stretch"}
+          maxW={["392px", "390px", "100%"]}
+          columns={1}
+          spacing={6}
+        >
+          {circuitsClean.map((circuit, index) =>
+            <CircuitStats
+              key={index}
+              {...{circuit}}
+            />
+          )}
+        </SimpleGrid>
+      </Box>
+    </TabPanel>
+  );
+}

--- a/web/src/components/ProjectTabZKey.tsx
+++ b/web/src/components/ProjectTabZKey.tsx
@@ -1,0 +1,132 @@
+import {
+  Box,
+  Text,
+  TabPanel,
+  Button,
+  useClipboard,
+} from "@chakra-ui/react";
+import { FaCloudDownloadAlt, FaCopy } from "react-icons/fa";
+
+import { useProjectPageContext } from "../context/ProjectPageContext";
+import { CeremonyState } from "../helpers/interfaces";
+import { truncateString } from "../helpers/utils";
+
+export const ProjectTabZKey: React.FC = ({ project }) => {
+  const {
+    latestZkeys,
+    finalBeacon,
+    finalZkeys,
+  } = useProjectPageContext();
+
+  const beaconValue = finalBeacon?.beacon
+  const beaconHash = finalBeacon?.beaconHash
+
+  const { onCopy: copyBeaconValue, hasCopied: copiedBeaconValue } = useClipboard(beaconValue || "")
+  const { onCopy: copyBeaconHash, hasCopied: copiedBeaconHash } = useClipboard(beaconHash || "")
+
+  return (
+    <TabPanel textAlign={"center"}>
+      {
+        project?.ceremony.data.state === CeremonyState.FINALIZED && beaconHash && beaconValue &&
+        <div>
+          <Text fontSize={14} fontWeight="bold">
+          Final contribution beacon
+          </Text>
+          <Button
+            margin={4}
+            leftIcon={<Box as={FaCopy} w={3} h={3} />}
+            variant="outline"
+            fontSize={12}
+            fontWeight={"regular"}
+            onClick={copyBeaconValue}
+          >
+            {
+              copiedBeaconValue ?
+              "Copied"
+              : `Beacon ${finalBeacon?.beacon}`
+            }
+          </Button>
+          <Button
+            margin={4}
+            leftIcon={<Box as={FaCopy} w={3} h={3} />}
+            variant="outline"
+            fontSize={12}
+            fontWeight={"regular"}
+            onClick={copyBeaconHash}
+          >
+            {
+              copiedBeaconHash ?
+              "Copied"
+              : `Beacon hash ${truncateString(finalBeacon?.beaconHash)}`
+            }
+          </Button>
+        </div>
+      }
+      <Text p={4} fontSize={14} fontWeight="bold">
+        Download Final ZKey(s)
+      </Text>
+      <Text color="gray.500">
+        Press the button below to download the final ZKey files from the S3 bucket.
+      </Text>
+      {
+        finalZkeys?.map((zkey, index) => {
+          return (
+            <a
+              href={zkey.zkeyURL}
+              key={index}
+            >
+              <Button
+                margin={"20px"}
+                leftIcon={<Box as={FaCloudDownloadAlt} w={3} h={3} />}
+                fontSize={12}
+                variant="outline"
+                fontWeight={"regular"}
+                isDisabled={
+                  project?.ceremony.data.state !== CeremonyState.FINALIZED ? true : false
+                }
+              >
+              Download {zkey.zkeyFilename}
+            </Button>
+          </a>
+          )
+        })
+      }
+      {
+        project?.ceremony.data.state === CeremonyState.FINALIZED &&
+        <>
+          <Text p={4} fontSize={14} fontWeight="bold">
+          Download Last ZKey(s)
+          </Text>
+          <Text color="gray.500">
+            You can use this zKey(s) with the beacon value to verify that the final zKey(s) was computed correctly.
+          </Text>
+          {
+            latestZkeys?.map((zkey, index) => {
+              return (
+                <a
+                  href={zkey.zkeyURL}
+                  key={index}
+                >
+                  <Button
+                    margin={"20px"}
+                    key={index}
+                    leftIcon={<Box as={FaCloudDownloadAlt} w={3} h={3} />}
+                    fontSize={12}
+                    variant="outline"
+                    fontWeight={"regular"}
+                    isDisabled={
+                      project?.ceremony.data.state !== CeremonyState.FINALIZED ? true : false
+                    }
+                  >
+                    Download {zkey.zkeyFilename}
+                  </Button>
+                </a>
+              )
+            })
+          }
+        </>
+      }
+    </TabPanel>
+  );
+}
+

--- a/web/src/context/ProjectPageContext.tsx
+++ b/web/src/context/ProjectPageContext.tsx
@@ -15,11 +15,18 @@ import {
   CircuitDocumentReferenceAndData,
   FinalBeacon,
   ParticipantDocumentReferenceAndData,
-  ProjectData,
   ProjectPageContextProps,
   ZkeyDownloadLink
 } from "../helpers/interfaces";
-import { checkIfUserContributed, findLargestConstraint, formatZkeyIndex, processItems } from "../helpers/utils";
+import {
+  bytesToMegabytes,
+  checkIfUserContributed,
+  findLargestConstraint,
+  formatZkeyIndex,
+  parseDate,
+  processItems,
+  truncateString,
+} from "../helpers/utils";
 import { awsRegion, bucketPostfix, finalContributionIndex, maxConstraintsForBrowser } from "../helpers/constants";
 
 export const ProjectDataSchema = z.object({
@@ -28,15 +35,12 @@ export const ProjectDataSchema = z.object({
   contributions: z.optional(z.array(z.any()))
 });
 
-export const defaultProjectData: ProjectData = {};
-
 type ProjectPageProviderProps = {
   children: React.ReactNode;
 };
 
 const ProjectPageContext = createContext<ProjectPageContextProps>({
   hasUserContributed: false,
-  projectData: defaultProjectData,
   isLoading: false,
   runTutorial: false,
   avatars: [],
@@ -49,13 +53,14 @@ export const useProjectPageContext = () => useContext(ProjectPageContext);
 export const ProjectPageProvider: React.FC<ProjectPageProviderProps> = ({ children }) => {
   const navigate = useNavigate();
   const { loading: isLoading, setLoading: setIsLoading, runTutorial } = useContext(StateContext);
-  const [ projectData, setProjectData ] = useState<ProjectData | null>(defaultProjectData);
   const [ avatars, setAvatars ] = useState<string[]>([]);
   const [ hasUserContributed, setHasUserContributed ] = useState<boolean>(false);
   const [ largestCircuitConstraints, setLargestCircuitConstraints ] = useState<number>(maxConstraintsForBrowser + 1) // contribution on browser has 100000 max constraints
   const [ finalZkeys, setFinalZkeys ] = useState<ZkeyDownloadLink[]>([])
   const [ latestZkeys, setLatestZkeys ] = useState<ZkeyDownloadLink[]>([])
   const [ finalBeacon, setFinalBeacon ] = useState<FinalBeacon>()
+  const [ circuitsClean, setCircuitsClean ] = useState([]);
+  const [ contributionsClean, setContributionsClean ] = useState([]);
 
   const { projects } = useStateContext();
   const { ceremonyName } = useParams();
@@ -123,7 +128,51 @@ export const ProjectPageProvider: React.FC<ProjectPageProviderProps> = ({ childr
         
         const parsedData = ProjectDataSchema.parse(updatedProjectData);
 
-        setProjectData(parsedData);
+        setCircuitsClean(
+          parsedData.circuits?.map((circuit) => ({
+            template: circuit.data.template,
+            compiler: circuit.data.compiler,
+            name: circuit.data.name,
+            description: circuit.data.description,
+            constraints: circuit.data.metadata?.constraints,
+            pot: circuit.data.metadata?.pot,
+            privateInputs: circuit.data.metadata?.privateInputs,
+            publicInputs: circuit.data.metadata?.publicInputs,
+            curve: circuit.data.metadata?.curve,
+            wires: circuit.data.metadata?.wires,
+            completedContributions: circuit.data.waitingQueue?.completedContributions,
+            currentContributor: circuit.data.waitingQueue?.currentContributor,
+            memoryRequirement: bytesToMegabytes(circuit.data.zKeySizeInBytes ?? Math.pow(1024, 2))
+              .toString()
+              .slice(0, 5),
+            avgTimingContribution: Math.round(Number(circuit.data.avgTimings?.fullContribution) / 1000),
+            maxTiming: Math.round((Number(circuit.data.avgTimings?.fullContribution) * 1.618) / 1000)
+          })) ?? []
+        );
+
+        // parse contributions and sort by zkey name. FIlter for valid contribs.
+        setContributionsClean(
+          parsedData.contributions?.map((contribution) => ({
+            doc: contribution.data.files?.lastZkeyFilename ?? "",
+            verificationComputationTime: contribution.data?.verificationComputationTime ?? "",
+            valid: contribution.data?.valid ?? false,
+            lastUpdated: parseDate(contribution.data?.lastUpdated ?? ""),
+            lastZkeyBlake2bHash: truncateString(contribution.data?.files?.lastZkeyBlake2bHash ?? "", 10),
+            transcriptBlake2bHash: truncateString(
+              contribution.data?.files?.transcriptBlake2bHash ?? "",
+              10
+            )
+          })).slice()
+            .filter((c: any) => c.valid)
+            .sort((a: any, b: any) => {
+            const docA = a.doc.toLowerCase()
+            const docB = b.doc.toLowerCase()
+
+            if (docA < docB) return -1
+            if (docA > docB) return 1
+            return 0
+          }) ?? []
+        );
 
         const avatars = await getParticipantsAvatar(projectId)
         setAvatars(avatars)
@@ -146,7 +195,18 @@ export const ProjectPageProvider: React.FC<ProjectPageProviderProps> = ({ childr
 
 
   return (
-    <ProjectPageContext.Provider value={{ latestZkeys, finalBeacon, finalZkeys, largestCircuitConstraints, hasUserContributed, projectData, isLoading, runTutorial, avatars }}>
+    <ProjectPageContext.Provider value={{
+      latestZkeys,
+      finalBeacon,
+      finalZkeys,
+      largestCircuitConstraints,
+      hasUserContributed,
+      circuitsClean,
+      contributionsClean,
+      isLoading,
+      runTutorial,
+      avatars
+    }}>
       {children}
     </ProjectPageContext.Provider>
   );

--- a/web/src/helpers/interfaces.ts
+++ b/web/src/helpers/interfaces.ts
@@ -1,6 +1,5 @@
 import { DocumentData, DocumentReference } from "firebase/firestore";
 import { z } from "zod";
-import { ProjectDataSchema } from "../context/ProjectPageContext";
 
 /**
  * Define different states of a ceremony.
@@ -535,19 +534,8 @@ export interface State {
 
 /**
  * Define the data structure for the project page context.
- * @typedef {Object} ProjectData
- * @property {string} ceremonyName - the name of the ceremony.
- * @property {string} ceremonyDescription - the description of the ceremony.
- * @property {string} ceremonyState - the state of the ceremony.
- * @property {string} ceremonyType - the type of the ceremony.
- */
-export type ProjectData = z.infer<typeof ProjectDataSchema>;
-
-/**
- * Define the data structure for the project page context.
  * @typedef {Object} ProjectPageContextProps
  * @property {boolean} hasUserContributed - true if the user has contributed to the project; otherwise false.
- * @property {ProjectData} projectData - the data about the project.
  * @property {boolean} isLoading - true if the data is being loaded; otherwise false.
  * @property {boolean} runTutorial - true if the tutorial should be run; otherwise false.
  * @property {string[]} [avatars] - the list of avatars for the participants.
@@ -558,7 +546,6 @@ export type ProjectData = z.infer<typeof ProjectDataSchema>;
  */
 export type ProjectPageContextProps = {
   hasUserContributed: boolean
-  projectData: ProjectData | null
   isLoading: boolean
   runTutorial: boolean
   avatars?: string[]

--- a/web/src/pages/ProjectPage.tsx
+++ b/web/src/pages/ProjectPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { useParams } from "react-router-dom";
 import {
   Box,
@@ -10,50 +10,29 @@ import {
   TabList,
   TabPanels,
   Tab,
-  TabPanel,
   Button,
-  Stat,
-  StatLabel,
-  StatNumber,
-  Tag,
   Heading,
-  Spacer,
   Breadcrumb,
   BreadcrumbItem,
-  Flex,
-  Icon,
-  SimpleGrid,
-  SkeletonText,
-  Table,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tooltip,
-  Tr,
-  Skeleton,
-  Stack,
   SkeletonCircle,
+  SkeletonText,
   useClipboard,
 } from "@chakra-ui/react";
 import { StateContext } from "../context/StateContext";
+import { useProjectPageContext } from "../context/ProjectPageContext";
+import { FaCopy } from "react-icons/fa";
+import { CeremonyState } from "../helpers/interfaces";
 import {
-  ProjectDataSchema,
-  useProjectPageContext
-} from "../context/ProjectPageContext";
-import { FaCloudDownloadAlt, FaCopy } from "react-icons/fa";
-import { CeremonyState, ProjectData } from "../helpers/interfaces";
-import { FiTarget, FiZap, FiEye, FiUser, FiMapPin, FiWifi } from "react-icons/fi";
-import {
-  bytesToMegabytes,
   formatDate,
   getTimeDifference,
-  parseDate,
   singleProjectPageSteps,
   truncateString,
-  parseRepoRoot
 } from "../helpers/utils";
 import Joyride, { STATUS } from "react-joyride";
+import { ProjectTabStats } from "../components/ProjectTabStats";
+import { ProjectTabContributions } from "../components/ProjectTabContributions";
+import { ProjectTabAbout } from "../components/ProjectTabAbout";
+import { ProjectTabZKey } from "../components/ProjectTabZKey";
 import ScrollingAvatars from "../components/Avatars";
 import { Contribution } from "../components/Contribution";
 import { maxConstraintsForBrowser } from "../helpers/constants";
@@ -65,7 +44,18 @@ type RouteParams = {
 const ProjectPage: React.FC = () => {
   const { ceremonyName } = useParams<RouteParams>();
   const { user, projects, setRunTutorial, runTutorial } = useContext(StateContext);
-  const { latestZkeys, finalBeacon, finalZkeys, hasUserContributed, projectData, isLoading, avatars, largestCircuitConstraints } = useProjectPageContext();
+  const {
+    hasUserContributed,
+    isLoading,
+    largestCircuitConstraints
+  } = useProjectPageContext();
+
+  const [project, setProject] = useState(null);
+  useEffect(() => {
+    // find a project with the given ceremony name
+    setProject(projects.find((p) => p.ceremony.data.title === ceremonyName));
+  }, [projects]);
+
   // handle the callback from joyride
   const handleJoyrideCallback = (data: any) => {
     const { status } = data;
@@ -75,56 +65,6 @@ const ProjectPage: React.FC = () => {
     }
   };
 
-  // find a project with the given ceremony name
-  const project = projects.find((p) => p.ceremony.data.title === ceremonyName);
-
-  // Validate the project data against the schema
-  const validatedProjectData: ProjectData = ProjectDataSchema.parse(projectData);
-
-  const circuitsClean =
-    validatedProjectData.circuits?.map((circuit) => ({
-      template: circuit.data.template,
-      compiler: circuit.data.compiler,
-      name: circuit.data.name,
-      description: circuit.data.description,
-      constraints: circuit.data.metadata?.constraints,
-      pot: circuit.data.metadata?.pot,
-      privateInputs: circuit.data.metadata?.privateInputs,
-      publicInputs: circuit.data.metadata?.publicInputs,
-      curve: circuit.data.metadata?.curve,
-      wires: circuit.data.metadata?.wires,
-      completedContributions: circuit.data.waitingQueue?.completedContributions,
-      currentContributor: circuit.data.waitingQueue?.currentContributor,
-      memoryRequirement: bytesToMegabytes(circuit.data.zKeySizeInBytes ?? Math.pow(1024, 2))
-        .toString()
-        .slice(0, 5),
-      avgTimingContribution: Math.round(Number(circuit.data.avgTimings?.fullContribution) / 1000),
-      maxTiming: Math.round((Number(circuit.data.avgTimings?.fullContribution) * 1.618) / 1000)
-    })) ?? [];
-
-  // parse contributions and sort by zkey name. FIlter for valid contribs.
-  const contributionsClean =
-    validatedProjectData.contributions?.map((contribution) => ({
-      doc: contribution.data.files?.lastZkeyFilename ?? "",
-      verificationComputationTime: contribution.data?.verificationComputationTime ?? "",
-      valid: contribution.data?.valid ?? false,
-      lastUpdated: parseDate(contribution.data?.lastUpdated ?? ""),
-      lastZkeyBlake2bHash: truncateString(contribution.data?.files?.lastZkeyBlake2bHash ?? "", 10),
-      transcriptBlake2bHash: truncateString(
-        contribution.data?.files?.transcriptBlake2bHash ?? "",
-        10
-      )
-    })).slice()
-      .filter((c: any) => c.valid)
-      .sort((a: any, b: any) => {
-      const docA = a.doc.toLowerCase()
-      const docB = b.doc.toLowerCase()
-
-      if (docA < docB) return -1
-      if (docA > docB) return 1
-      return 0
-    }) ?? [];
-
   // Commands
   const contributeCommand =
     !project || isLoading
@@ -132,15 +72,11 @@ const ProjectPage: React.FC = () => {
       : `phase2cli auth && phase2cli contribute -c ${project?.ceremony.data.prefix}`;
   const installCommand = `npm install -g @p0tion/phase2cli`;
   const authCommand = `phase2cli auth`;
-  const beaconValue = finalBeacon?.beacon
-  const beaconHash = finalBeacon?.beaconHash
- 
+
   // Hook for clipboard
   const { onCopy: copyContribute, hasCopied: copiedContribute } = useClipboard(contributeCommand);
   const { onCopy: copyInstall, hasCopied: copiedInstall } = useClipboard(installCommand);
   const { onCopy: copyAuth, hasCopied: copiedAuth } = useClipboard(authCommand);
-  const { onCopy: copyBeaconValue, hasCopied: copiedBeaconValue } = useClipboard(beaconValue || "")
-  const { onCopy: copyBeaconHash, hasCopied: copiedBeaconHash } = useClipboard(beaconHash || "")
 
   return (
     <>
@@ -311,7 +247,7 @@ const ProjectPage: React.FC = () => {
               maxW={["390px", "390px", "100%"]}
               minW={["390px", "390px", null]}
             > 
-              <ScrollingAvatars images={avatars}/>
+              <ScrollingAvatars />
             </VStack>
             <VStack
               minH={[null, null, "100vh"]}
@@ -340,287 +276,10 @@ const ProjectPage: React.FC = () => {
                 </TabList>
 
                 <TabPanels py={4}>
-                  <TabPanel>
-                    <Box alignItems="center" alignSelf={"stretch"} w="full">
-                      <SimpleGrid
-                        alignSelf={"stretch"}
-                        maxW={["392px", "390px", "100%"]}
-                        columns={1}
-                        spacing={6}
-                      >
-                        {circuitsClean.map((circuit, index) => (
-                          <Box key={index} borderWidth={1} borderRadius="lg" p={4}>
-                            <Heading fontSize={16} size="md" mb={2}>
-                              {circuit.name} - {circuit.description}
-                            </Heading>
-                            <Flex wrap="wrap" mb={4}>
-                              <Tag fontSize={10} size="sm" colorScheme="purple" mr={2} mb={2}>
-                                <Icon as={FiTarget} mr={1} />
-                                Constraints: {circuit.constraints}
-                              </Tag>
-                              <Tag fontSize={10} size="sm" colorScheme="cyan" mr={2} mb={2}>
-                                <Icon as={FiZap} mr={1} />
-                                Pot: {circuit.pot}
-                              </Tag>
-                              <Tag fontSize={10} size="sm" colorScheme="yellow" mr={2} mb={2}>
-                                <Icon as={FiEye} mr={1} />
-                                Private Inputs: {circuit.privateInputs}
-                              </Tag>
-                              <Tag fontSize={10} size="sm" colorScheme="pink" mr={2} mb={2}>
-                                <Icon as={FiUser} mr={1} />
-                                Public Inputs: {circuit.publicInputs}
-                              </Tag>
-                              <Tag fontSize={10} size="sm" colorScheme="blue" mr={2} mb={2}>
-                                <Icon as={FiMapPin} mr={1} />
-                                Curve: {circuit.curve}
-                              </Tag>
-                              <Tag fontSize={10} size="sm" colorScheme="teal" mr={2} mb={2}>
-                                <Icon as={FiWifi} mr={1} />
-                                Wires: {circuit.wires}
-                              </Tag>
-                            </Flex>
-                            <SimpleGrid columns={[2, 2]} spacing={6}>
-                              <Flex justify="space-between" align="center">
-                                <Stat>
-                                  <StatLabel fontSize={12}>Completed Contributions</StatLabel>
-                                  <StatNumber fontSize={16}>
-                                    {circuit.completedContributions}
-                                  </StatNumber>
-                                </Stat>
-                              </Flex>
-                              <Stat>
-                                <StatLabel fontSize={12}>Memory Requirement</StatLabel>
-                                <StatNumber fontSize={16}>
-                                  {circuit.memoryRequirement} mb
-                                </StatNumber>
-                              </Stat>
-                              <Stat>
-                                <StatLabel fontSize={12}>Avg Contribution Time</StatLabel>
-                                <StatNumber fontSize={16}>
-                                  {circuit.avgTimingContribution}s
-                                </StatNumber>
-                              </Stat>
-                              <Stat>
-                                <StatLabel fontSize={12}>Max Contribution Time</StatLabel>
-                                <StatNumber fontSize={16}>{circuit.maxTiming}s</StatNumber>
-                              </Stat>
-                            </SimpleGrid>
-                          </Box>
-                        ))}
-                      </SimpleGrid>
-                    </Box>
-                  </TabPanel>
-                  <TabPanel alignSelf={"stretch"}>
-                    <HStack justifyContent={"space-between"} alignSelf={"stretch"}>
-                      <Heading fontSize="18" mb={6} fontWeight={"bold"} letterSpacing={"3%"}>
-                        Contributions
-                      </Heading>
-                      <Spacer />
-                    </HStack>
-                    <Box overflowX="auto">
-                      {!contributionsClean || isLoading ? (
-                        <Stack>
-                          <Skeleton height="20px" />
-                          <Skeleton height="20px" />
-                          <Skeleton height="20px" />
-                        </Stack>
-                      ) : (
-                        <Table fontSize={12} variant="simple">
-                          <Thead>
-                            <Tr>
-                              <Th>Doc</Th>
-                              <Th>Contribution Date</Th>
-                              <Th>Hashes</Th>
-                            </Tr>
-                          </Thead>
-                          <Tbody>
-                            {contributionsClean.map((contribution, index) => (
-                              <Tr key={index}>
-                                <Td>{contribution.doc}</Td>
-                                <Td>{contribution.lastUpdated}</Td>
-                                <Td>
-                                  <Tooltip
-                                    label={contribution.lastZkeyBlake2bHash}
-                                    aria-label="Last Zkey Hash"
-                                  >
-                                    <Tag fontSize={12}>{contribution.lastZkeyBlake2bHash}</Tag>
-                                  </Tooltip>
-                                </Td>
-                              </Tr>
-                            ))}
-                          </Tbody>
-                        </Table>
-                      )}
-                    </Box>
-                  </TabPanel>
-                  <TabPanel>
-                  <VStack
-                      alignSelf={"stretch"}
-                      alignItems={"center"}
-                      justifyContent={"center"}
-                      spacing={8}
-                      py={0}
-                    >
-                      <Box alignItems="center" alignSelf={"stretch"} w="full">
-                      <SimpleGrid
-                        alignSelf={"stretch"}
-                        maxW={["392px", "390px", "100%"]}
-                        columns={1}
-                        spacing={6}
-                      >
-                        {circuitsClean.map((circuit, index) => (
-                          <Box key={index} borderWidth={1} borderRadius="lg" p={4}>
-                            <Heading fontSize={16} size="md" mb={2}>
-                              {circuit.name} - {circuit.description}
-                            </Heading>
-                            <SimpleGrid columns={[2, 2]} spacing={4}>
-                              <Flex justify="space-between" align="center">
-                                <Stat>
-                                  <StatLabel fontSize={12}>Parameters</StatLabel>
-                                  <StatNumber fontSize={16}>
-                                    {
-                                      circuit.template.paramsConfiguration && circuit.template.paramsConfiguration.length > 0 ?
-                                      circuit.template.paramsConfiguration.join(" ") :
-                                      circuit.template.paramConfiguration && circuit.template.paramConfiguration.length > 0 ?
-                                      circuit.template.paramConfiguration.join(" ") :
-                                      "No parameters"
-                                    }
-                                  </StatNumber>
-                                </Stat>
-                              </Flex>
-                              <Stat>
-                                <StatLabel fontSize={12}>Commit Hash</StatLabel>
-                                <StatNumber fontSize={16}>
-                                  <a href={`${parseRepoRoot(circuit.template.source)}/tree/${circuit.template.commitHash}`} target="_blank">
-                                    {truncateString(circuit.template.commitHash, 6)}
-                                  </a>
-                                </StatNumber>
-                              </Stat>
-                              <Stat>
-                                <StatLabel fontSize={12}>Template Link</StatLabel>
-                                <StatNumber fontSize={16}>
-                                  <a href={circuit.template.source} target="_blank">
-                                  {truncateString(circuit.template.source, 16)}
-                                  </a>
-                                </StatNumber>
-                              </Stat>
-                              <Stat>
-                                <StatLabel fontSize={12}>Compiler Version</StatLabel>
-                                <StatNumber fontSize={16}>
-                                  {circuit.compiler.version}
-                                </StatNumber>
-                              </Stat>
-                            </SimpleGrid>
-                          </Box>
-                        ))}
-                      </SimpleGrid>
-                    </Box>
-                      
-                    </VStack>
-                  </TabPanel>
-                  <TabPanel textAlign={"center"}>
-                    {
-                      project?.ceremony.data.state === CeremonyState.FINALIZED && beaconHash && beaconValue &&
-                      <div>
-                        <Text fontSize={14} fontWeight="bold">
-                        Final contribution beacon
-                        </Text>
-                        <Button 
-                          margin={4}
-                          leftIcon={<Box as={FaCopy} w={3} h={3} />}
-                          variant="outline"
-                          fontSize={12}
-                          fontWeight={"regular"}
-                          onClick={copyBeaconValue}
-                        >
-                          {
-                            copiedBeaconValue ?
-                            "Copied"
-                            : `Beacon ${finalBeacon?.beacon}`
-                          }
-                        </Button>
-                        <Button 
-                          margin={4}
-                          leftIcon={<Box as={FaCopy} w={3} h={3} />}
-                          variant="outline"
-                          fontSize={12}
-                          fontWeight={"regular"}
-                          onClick={copyBeaconHash}
-                        >
-                          {
-                            copiedBeaconHash ?
-                            "Copied"
-                            : `Beacon hash ${truncateString(finalBeacon?.beaconHash)}`
-                          }
-                        </Button>
-                      </div>
-                    }
-                    <Text p={4} fontSize={14} fontWeight="bold">
-                      Download Final ZKey(s)
-                    </Text>
-                    <Text color="gray.500">
-                      Press the button below to download the final ZKey files from the S3 bucket.
-                    </Text>
-                    {
-                      finalZkeys?.map((zkey, index) => {
-                        return (
-                          <a
-                            href={zkey.zkeyURL}
-                            key={index}
-                          >
-                            <Button
-                              margin={"20px"}
-                              leftIcon={<Box as={FaCloudDownloadAlt} w={3} h={3} />}
-                              fontSize={12}
-                              variant="outline"
-                              fontWeight={"regular"}
-                              isDisabled={
-                                project?.ceremony.data.state !== CeremonyState.FINALIZED ? true : false
-                              }
-                            >
-                            Download {zkey.zkeyFilename}
-                          </Button>
-                        </a>
-                        )
-                      })
-                    }
-                    {
-                      project?.ceremony.data.state === CeremonyState.FINALIZED &&
-                      <>
-                        <Text p={4} fontSize={14} fontWeight="bold">
-                        Download Last ZKey(s)
-                        </Text>
-                        <Text color="gray.500">
-                          You can use this zKey(s) with the beacon value to verify that the final zKey(s) was computed correctly.
-                        </Text>
-                        {
-                          latestZkeys?.map((zkey, index) => {
-                            return (
-                              <a
-                                href={zkey.zkeyURL}
-                                key={index}
-                              >
-                                <Button
-                                  margin={"20px"}
-                                  key={index}
-                                  leftIcon={<Box as={FaCloudDownloadAlt} w={3} h={3} />}
-                                  fontSize={12}
-                                  variant="outline"
-                                  fontWeight={"regular"}
-                                  isDisabled={
-                                    project?.ceremony.data.state !== CeremonyState.FINALIZED ? true : false
-                                  }
-                                >
-                                  Download {zkey.zkeyFilename}
-                                </Button>
-                              </a>
-                            )
-                          })
-                        }
-                      </>
-                    }
-                   
-                  </TabPanel>
+                  <ProjectTabStats />
+                  <ProjectTabContributions />
+                  <ProjectTabAbout />
+                  <ProjectTabZKey {...{project}} />
                 </TabPanels>
               </Tabs>
             </VStack>


### PR DESCRIPTION
I want to do something about the performance of this site (that Semaphore v4 page hangs my firefox for a minute) but I had to start here, breaking up the giant `ProjectPage` tabs into individual components so it's easier to reason about what's going on. That file is now less than half as long and contains many fewer imports.

I haven't looked into what's causing the slowdown yet but this is a start in that direction.