### PR TITLE
chore: gitignore firebase serviceAccountKey

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 
 # Firebase
 .firebase 
+.serviceAccountKey.json


### PR DESCRIPTION
# Description

When deploying DefinitelySetup to firebase, it is nice to have git ignore the `.serviceAccountKey.json` file.