### PR TITLE
fix: showing error messages without crashing the site

### DIFF
--- a/web/src/helpers/p0tion.ts
+++ b/web/src/helpers/p0tion.ts
@@ -129,7 +129,7 @@ export const contribute = async (ceremonyId: string, setStatus: (message: string
         const participant = await getDocumentById(`ceremonies/${ceremonyId}/participants`, user.uid)
         await listenToParticipantDocumentChanges(participant, ceremonyId, participantProviderId!, token, setStatus)
     } catch (error: any) {
-        setStatus(error)
+        setStatus(`Unexpected error during contribution: ${JSON.stringify(error)}`, false)
     }
 
 }


### PR DESCRIPTION
# Description

The website crashed when handling an error during the contribution.
Fixed by passing the proper parameters to `setStatus`.

# How Has This Been Tested?

-   [x] Built and deployed without errors
-   [x] Completing the [Galactica Network Ceremony](https://ceremony.galactica.com/projects/Galactica%20ZK%20Ceremony)